### PR TITLE
use appid of official VLC app in example

### DIFF
--- a/README
+++ b/README
@@ -66,7 +66,7 @@ the application identifier like this:
 
 The following example mounts the documents folder of the VLC app to /mnt:
 
-	$ ifuse --appid com.appladium.vlc /mnt
+	$ ifuse --appid org.videolan.vlc-ios /mnt
 
 Addtional help can be shown using:
 


### PR DESCRIPTION
The appid of the official VLC app is `org.videolan.vlc-ios`. See `CFBundleIdentifier` here:
http://git.videolan.org/?p=vlc-ports/ios.git;a=blob;f=AspenProject/VLC+for+iOS-Info.plist;h=2b07bb8037c16df6b488313aa98beb406ed099b3;hb=HEAD#l53
