### PR TITLE
Allow visibility to all app subdirs when mounting an appid

### DIFF
--- a/src/ifuse.c
+++ b/src/ifuse.c
@@ -626,7 +626,7 @@ static void print_usage()
 	fprintf(stderr, "  -h, --help\t\tprint usage information\n");
 	fprintf(stderr, "  -V, --version\t\tprint version\n");
 #ifdef HAVE_LIBIMOBILEDEVICE_1_1
-	fprintf(stderr, "  --appid APPID\t\tmount 'Documents' folder of app identified by APPID\n");
+	fprintf(stderr, "  --appid APPID\t\tmount sandboxed folders of app identified by APPID\n");
 #endif
 	fprintf(stderr, "  --root\t\tmount root file system (jailbroken device required)\n");
 	fprintf(stderr, "  --debug\t\tenable libimobiledevice communication debugging\n");


### PR DESCRIPTION
You can't write in some of the subdirs, but its still nice to peek into them.
