### PR TITLE
Fix typo in error message

### DIFF
--- a/src/ifuse.c
+++ b/src/ifuse.c
@@ -743,7 +743,7 @@ static void list_available_apps(const char *udid)
 	instproxy_browse(ip, client_opts, &apps);
 
 	if (!apps || (plist_get_node_type(apps) != PLIST_ARRAY)) {
-		fprintf(stderr, "ERROR: instproxy_browse returnd an invalid plist?!\n");
+		fprintf(stderr, "ERROR: instproxy_browse returned an invalid plist?!\n");
 		goto leave_cleanup;
 	}
 


### PR DESCRIPTION
I guess it's pretty self-explanatory. There are few typos in various projects under libimobiledevice umbrella, PR should be trivial to merge.