### PR TITLE
Fix FUSE capability flags set during initialization.

### DIFF
--- a/src/ifuse.c
+++ b/src/ifuse.c
@@ -395,7 +395,7 @@ void *ifuse_init(struct fuse_conn_info *conn, struct fuse_config *cfg)
 {
 	afc_client_t afc = NULL;
 
-	conn->want &= FUSE_CAP_ASYNC_READ;
+	conn->want &= ~FUSE_CAP_ASYNC_READ;
 
 	if (house_arrest) {
 		afc_client_new_from_house_arrest_client(house_arrest, &afc);


### PR DESCRIPTION
The intent behind the line "conn->want &= FUSE_CAP_ASYNC_READ;" was likely to clear the FUSE_CAP_ASYNC_READ flag, but it actually clears all the other flags instead. This commit changes it to clear only that flag.

Fixes #107